### PR TITLE
Add webpackPreload and webpackPrefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Magic comments supported:
 * `webpackChunkName`
 * `webpackMode`
 * `webpackIgnore`
-
+* `webpackPreload`
+* `webpackPrefetch`
 
 ## Usage
 
@@ -48,7 +49,7 @@ module: {
         options: {
           webpackChunkName: true,
           webpackMode: 'lazy',
-          webpackIgnore: 'src/ignore/**/*.js'
+          webpackPreload: 'src/preload/**/*.js'
         }
       }
     }
@@ -85,23 +86,24 @@ module: {
 }
 ```
 
-You can also override the configuration passed in the `config` key by using the `overrides` key, which is an array of objects that look like:
+#### Overrides
+
+You can also override the configuration passed in the `config` key by using `overrides`, which is an array of objects that look like:
 
 ```js
 overrides: [
  {
-   // Array of globs or a specific file (can be a string too)
-   // Uses micromatch to compare the module filepath to the provided string
-   files: ['src/**/*.js', '!/src/skip/**/*.js']
-   // Other configuration keys for the comment type can go here too
+   // Can be an array of strings too
+   files: 'src/**/*.js',
    config: {
-     active: false
+     active: false,
+     // Possibly other configuration values
    }
  }
 ]
 ```
 
-Here's a more complete example using comment `config` and `overrides`:
+Here's a more complete example using `config` and `overrides` to customize how comments are applied:
 
 ```js
 module: {
@@ -189,21 +191,32 @@ const dynamicModule = await import(/* webpackChunkName: "path-to-some-module", w
 
 ### Options
 
-These are the options that can be configured under the loader `options`.
+These are the options that can be configured under the loader `options`. All comments accept an [`overrides`](./#overrides) key in addition to `config` when defined as an object.
 
 * `verbose`: Prints console statements of the updated `import()`s per module filepath during the webpack build. Useful for debugging your custom configurations.
 * `webpackChunkName`
   * `true`: Adds `webpackChunkName` comments to **all** dynamic imports using the full path to the imported module to construct the name, so `import('path/to/module')` becomes `import(/* webpackChunkName: "path-to-module" */ 'path/to/module')`. This is the default.
   * `false`: Disables adding the `webpackChunkName` comment globally.
+  * `some/glob/**/*.js`|`['/some/globs/**/*.js']`: Adds the comment with the default behavior of slugifying (hyphenating) the import path.
   * `config.active`: Boolean to enable/disable the comment.
   * `config.basename`: Boolean to use only the basename from the import path as the chunk name. Some relative path imports may end up with the same basename depsite importing different modules. Use in areas where you know the basenames are unique.
 * `webpackMode`
-  * `true`: Adds `webpackMode` comments to **all** dynamic imports using `lazy` so `import('path/to/module')` becomes `import(/* webpackMode: "lazy" */ 'path/to/module')`.
+  * `true`: Adds `webpackMode` comments to **all** dynamic imports using `lazy`, so `import('path/to/module')` becomes `import(/* webpackMode: "lazy" */ 'path/to/module')`.
   * `false`: Disables adding the `webpackChunkName` comment globally. This is the default.
   * `config.active`: Boolean to enable/disable the comment.
   * `config.mode`: String to set the mode. `lazy`, `lazy-once`, `eager`, or `weak`.
 * `webpackIgnore`
-  * `true`: Adds `webpackIgnore` comments to **all** dynamic imports `true` so `import('path/to/module')` becomes `import(/* webpackIgnore: true */ 'path/to/module')`.
+  * `true`: Adds `webpackIgnore` comments to **all** dynamic imports, so `import('path/to/module')` becomes `import(/* webpackIgnore: true */ 'path/to/module')`.
   * `false`: Disables adding the `webpackIgnore` comment globally. This is the default.
+  * `some/glob/**/*.js`|`['/some/globs/**/*.js']`: Adds the comment with a value of `true` to all module filepaths that match the string or array of strings.
+  * `config.active`: Boolean to enable/disable the comment.
+* `webpackPreload`
+  * `true`: Adds `webpackPreload` comments to **all** dynamic imports, so `import('path/to/module')` becomes `import(/* webpackPreload: true */ 'path/to/module')`.
+  * `false`: Disables adding the `webpackPreload` comment globally. This is the default.
+  * `some/glob/**/*.js`|`['/some/globs/**/*.js']`: Adds the comment with a value of `true` to all module filepaths that match the string or array of strings.
+  * `config.active`: Boolean to enable/disable the comment.
+* `webpackPrefetch`
+  * `true`: Adds `webpackPrefetch` comments to **all** dynamic imports, so `import('path/to/module')` becomes `import(/* webpackPrefetch: true */ 'path/to/module')`.
+  * `false`: Disables adding the `webpackPrefetch` comment globally. This is the default.
   * `some/glob/**/*.js`|`['/some/globs/**/*.js']`: Adds the comment with a value of `true` to all module filepaths that match the string or array of strings.
   * `config.active`: Boolean to enable/disable the comment.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const dynamicModule = await import(/* webpackChunkName: "path-to-some-module", w
 
 ### Options
 
-These are the options that can be configured under the loader `options`. All comments accept an [`overrides`](./#overrides) key in addition to `config` when defined as an object.
+These are the options that can be configured under the loader `options`. All comments accept an [`overrides`](#overrides) key in addition to `config` when defined as an object.
 
 * `verbose`: Prints console statements of the updated `import()`s per module filepath during the webpack build. Useful for debugging your custom configurations.
 * `webpackChunkName`

--- a/__tests__/comment.js
+++ b/__tests__/comment.js
@@ -1,0 +1,44 @@
+import { getCommenter } from '../src/comment.js'
+
+describe('getCommenter', () => {
+  it('creates a function for adding magic comments to imports', () => {
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackChunkName: true
+      })('import("./some/test/module.js")', '"./some/test/module.js"')
+    ).toBe('import(/* webpackChunkName: "some-test-module" */ "./some/test/module.js")')
+
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackChunkName: true,
+        webpackMode: 'eager',
+        webpackPrefetch: 'some/**/*.js',
+        webpackPreload: false
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe(
+      'import(/* webpackChunkName: "some-test-module", webpackMode: "eager", webpackPrefetch: true */ "./some/test/module")'
+    )
+
+    expect(
+      getCommenter('some/file/path.js', {
+        verbose: true,
+        webpackPreload: true,
+        webpackChunkName: true
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe(
+      'import(/* webpackPreload: true, webpackChunkName: "some-test-module" */ "./some/test/module")'
+    )
+
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackIgnore: true
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe('import(/* webpackIgnore: true */ "./some/test/module")')
+
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackChunkName: 'some/**/*.js'
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe('import(/* webpackChunkName: "some-test-module" */ "./some/test/module")')
+  })
+})

--- a/__tests__/strategy.js
+++ b/__tests__/strategy.js
@@ -6,7 +6,9 @@ describe('commentFor', () => {
       expect.objectContaining({
         webpackChunkName: expect.any(Function),
         webpackMode: expect.any(Function),
-        webpackIgnore: expect.any(Function)
+        webpackIgnore: expect.any(Function),
+        webpackPreload: expect.any(Function),
+        webpackPrefetch: expect.any(Function)
       })
     )
   })

--- a/__tests__/util.js
+++ b/__tests__/util.js
@@ -1,0 +1,38 @@
+import { filepathIsMatch, getOverrideConfig } from '../src/util.js'
+
+describe('filepathIsMatch', () => {
+  it('compares a filepath to glob patterns', () => {
+    expect(filepathIsMatch('some/file/path.js', 'some/**/*.js')).toEqual(true)
+    expect(
+      filepathIsMatch('some/file/path', ['some/**/*.js', '!some/file/*.js'])
+    ).toEqual(false)
+    expect(
+      filepathIsMatch('some/file/path.js', ['some/**/*.js', '!some/miss/*.js'])
+    ).toEqual(true)
+  })
+})
+
+describe('getOverrideConfig', () => {
+  const overrides = [
+    {
+      files: 'some/**/*.js',
+      config: {
+        test: true
+      }
+    }
+  ]
+
+  it('gets config overrides based on path globs', () => {
+    expect(
+      getOverrideConfig(overrides, 'some/file/path.js', { test: false })
+    ).toStrictEqual({
+      test: true
+    })
+  })
+
+  it('returns the passed config if filepath is not a match', () => {
+    const config = { test: 'it' }
+
+    expect(getOverrideConfig(overrides, 'miss/file/path.js', config)).toBe(config)
+  })
+})

--- a/__tests__/webpackChunkName.js
+++ b/__tests__/webpackChunkName.js
@@ -1,4 +1,4 @@
-import { webpackChunkName } from '../src/webpackChunkName'
+import { webpackChunkName } from '../src/webpackChunkName.js'
 
 describe('webpackChunkName', () => {
   it('returns a "webpackChunkName" magic comment', () => {
@@ -8,6 +8,12 @@ describe('webpackChunkName', () => {
     expect(webpackChunkName(testPath, testImportPath, true)).toEqual(
       'webpackChunkName: "some-import-path"'
     )
+    expect(webpackChunkName(testPath, testImportPath, 'some/**/*.js')).toEqual(
+      'webpackChunkName: "some-import-path"'
+    )
+    expect(
+      webpackChunkName(testPath, testImportPath, ['some/**/*.js', '!some/test/*.js'])
+    ).toEqual('')
     expect(
       webpackChunkName(testPath, testImportPath, { config: { basename: true } })
     ).toEqual('webpackChunkName: "path"')

--- a/__tests__/webpackIgnore.js
+++ b/__tests__/webpackIgnore.js
@@ -1,4 +1,4 @@
-import { webpackIgnore } from '../src/webpackIgnore'
+import { webpackIgnore } from '../src/webpackIgnore.js'
 
 describe('webpackIgnore', () => {
   it('returns a "webpackIgnore" magic comment', () => {

--- a/__tests__/webpackMode.js
+++ b/__tests__/webpackMode.js
@@ -1,4 +1,4 @@
-import { webpackMode } from '../src/webpackMode'
+import { webpackMode } from '../src/webpackMode.js'
 
 describe('webpackMode', () => {
   it('returns a "webpackMode" magic comment', () => {

--- a/__tests__/webpackPrefetch.js
+++ b/__tests__/webpackPrefetch.js
@@ -1,0 +1,31 @@
+import { webpackPrefetch } from '../src/webpackPrefetch.js'
+
+describe('webpackPrefetch', () => {
+  it('returns a "webpackPrefetch" magic comment', () => {
+    const testPath = 'some/test/module.js'
+    const testImportPath = './some/import/path'
+
+    expect(webpackPrefetch(testPath, testImportPath, true)).toEqual(
+      'webpackPrefetch: true'
+    )
+    expect(webpackPrefetch(testPath, testImportPath, 'some/**/*.js')).toEqual(
+      'webpackPrefetch: true'
+    )
+    expect(
+      webpackPrefetch(testPath, testImportPath, { config: { active: false } })
+    ).toEqual('')
+    expect(
+      webpackPrefetch(testPath, testImportPath, {
+        config: { active: false },
+        overrides: [
+          {
+            files: 'some/**/*.js',
+            config: {
+              active: true
+            }
+          }
+        ]
+      })
+    ).toEqual('webpackPrefetch: true')
+  })
+})

--- a/__tests__/webpackPreload.js
+++ b/__tests__/webpackPreload.js
@@ -1,0 +1,29 @@
+import { webpackPreload } from '../src/webpackPreload.js'
+
+describe('webpackPreload', () => {
+  it('returns a "webpackPreload" magic comment', () => {
+    const testPath = 'some/test/module.js'
+    const testImportPath = './some/import/path'
+
+    expect(webpackPreload(testPath, testImportPath, true)).toEqual('webpackPreload: true')
+    expect(webpackPreload(testPath, testImportPath, 'some/**/*.js')).toEqual(
+      'webpackPreload: true'
+    )
+    expect(
+      webpackPreload(testPath, testImportPath, { config: { active: false } })
+    ).toEqual('')
+    expect(
+      webpackPreload(testPath, testImportPath, {
+        config: { active: false },
+        overrides: [
+          {
+            files: 'some/**/*.js',
+            config: {
+              active: true
+            }
+          }
+        ]
+      })
+    ).toEqual('webpackPreload: true')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.4",
+        "schema-utils": "^3.1.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.14.8",
@@ -2583,8 +2584,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "node_modules/@types/node": {
       "version": "16.7.13",
@@ -2970,7 +2970,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2986,7 +2985,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
@@ -5010,8 +5008,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -5038,8 +5035,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -7764,8 +7760,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8685,7 +8680,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9140,7 +9134,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
       "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -10248,7 +10241,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -12505,8 +12497,7 @@
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "@types/node": {
       "version": "16.7.13",
@@ -12824,7 +12815,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12836,7 +12826,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
       "requires": {}
     },
     "ansi-colors": {
@@ -14390,8 +14379,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -14415,8 +14403,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -16471,8 +16458,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17180,8 +17166,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -17530,7 +17515,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
       "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -18393,7 +18377,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Add webpack magic comments to your dynamic imports during build time",
   "main": "dist",
   "type": "module",
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "loader-utils": "^2.0.0",
-    "micromatch": "^4.0.4"
+    "micromatch": "^4.0.4",
+    "schema-utils": "^3.1.1"
   }
 }

--- a/src/booleanComment.js
+++ b/src/booleanComment.js
@@ -1,0 +1,61 @@
+import { getOverrideSchema, filepathIsMatch } from './util'
+
+const defaultSchema = {
+  type: 'object',
+  properties: {
+    active: {
+      type: 'boolean'
+    }
+  },
+  additionalProperties: false
+}
+const getSchema = (commentSchema = defaultSchema) => ({
+  anyOf: [
+    { type: 'boolean' },
+    { type: 'string' },
+    {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    },
+    {
+      type: 'object',
+      properties: {
+        config: commentSchema,
+        overrides: getOverrideSchema(commentSchema)
+      },
+      required: ['config'],
+      additionalProperties: false
+    }
+  ]
+})
+const getConfig = (value, filepath, defaultConfig = { active: true }) => {
+  if (value === true) {
+    return defaultConfig
+  }
+
+  if (Array.isArray(value) || typeof value === 'string') {
+    return {
+      ...defaultConfig,
+      active: filepathIsMatch(filepath, value)
+    }
+  }
+
+  let config = { ...defaultConfig, ...value.config }
+
+  if (Array.isArray(value.overrides)) {
+    const { overrides } = value
+    const length = overrides.length
+
+    for (let i = 0; i < length; i++) {
+      if (filepathIsMatch(filepath, overrides[i].files)) {
+        return { ...config, ...overrides[i].config }
+      }
+    }
+  }
+
+  return config
+}
+
+export { getSchema, getConfig }

--- a/src/comment.js
+++ b/src/comment.js
@@ -1,32 +1,30 @@
 import { commentFor } from './strategy.js'
 
-const getCommenter =
-  (filepath, options = { webpackChunkName: true }) =>
-  (match, capturedImportPath) => {
-    const importPath = capturedImportPath.trim()
-    const { verbose, ...magicCommentOptions } = options
-    const magicComment = Object.keys(magicCommentOptions)
-      .map(key => {
-        const option = magicCommentOptions[key]
+const getCommenter = (filepath, options) => (match, capturedImportPath) => {
+  const importPath = capturedImportPath.trim()
+  const { verbose, ...magicCommentOptions } = options
+  const magicComment = Object.keys(magicCommentOptions)
+    .map(key => {
+      const option = magicCommentOptions[key]
 
-        if (option) {
-          return commentFor[key](filepath, importPath, option)
-        }
+      if (option) {
+        return commentFor[key](filepath, importPath, option)
+      }
 
-        return null
-      })
-      .filter(comment => comment)
-    const magicImport = match.replace(
-      capturedImportPath,
-      `/* ${magicComment.join(', ')} */ ${importPath}`
-    )
+      return null
+    })
+    .filter(comment => comment)
+  const magicImport = match.replace(
+    capturedImportPath,
+    `/* ${magicComment.join(', ')} */ ${importPath}`
+  )
 
-    if (verbose) {
-      // eslint-disable-next-line no-console
-      console.log('\x1b[32m%s\x1b[0m', '[MCL]', `${filepath} : ${magicImport}`)
-    }
-
-    return magicImport
+  if (verbose) {
+    // eslint-disable-next-line no-console
+    console.log('\x1b[32m%s\x1b[0m', '[MCL]', `${filepath} : ${magicImport}`)
   }
+
+  return magicImport
+}
 
 export { getCommenter }

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,15 +1,23 @@
 import { getOptions } from 'loader-utils'
+import { validate } from 'schema-utils'
 
+import { schema } from './schema.js'
 import { getCommenter } from './comment.js'
 
 const dynamicImportsWithoutComments =
   /(?<!\w|\*[\s\w]*?|\/\/\s*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`].+['"`]\s*)\)/g
 const loader = function (source, map, meta) {
   const options = getOptions(this)
+  const optionKeys = Object.keys(options)
+
+  validate(schema, options, {
+    name: 'magic-comments-loader'
+  })
+
   const filepath = this.utils.contextify(this.rootContext, this.resourcePath)
   const magicComments = getCommenter(
     filepath.replace(/^\.\/?/, ''),
-    Object.keys(options).length > 0 ? options : undefined
+    optionKeys.length > 0 ? options : { webpackChunkName: true }
   )
 
   this.callback(

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,22 @@
+import { schema as webpackChunkNameSchema } from './webpackChunkName.js'
+import { schema as webpackModeSchema } from './webpackMode.js'
+import { schema as webpackIgnoreSchema } from './webpackIgnore.js'
+import { schema as webpackPrefetchSchema } from './webpackPrefetch.js'
+import { schema as webpackPreloadSchema } from './webpackPreload.js'
+
+const schema = {
+  type: 'object',
+  properties: {
+    verbose: {
+      type: 'boolean'
+    },
+    webpackChunkName: webpackChunkNameSchema,
+    webpackMode: webpackModeSchema,
+    webpackIgnore: webpackIgnoreSchema,
+    webpackPrefetch: webpackPrefetchSchema,
+    webpackPreload: webpackPreloadSchema
+  },
+  additionalProperties: false
+}
+
+export { schema }

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -1,11 +1,15 @@
 import { webpackChunkName } from './webpackChunkName.js'
 import { webpackMode } from './webpackMode.js'
 import { webpackIgnore } from './webpackIgnore.js'
+import { webpackPreload } from './webpackPreload.js'
+import { webpackPrefetch } from './webpackPrefetch.js'
 
 const commentFor = {
   webpackChunkName,
   webpackMode,
-  webpackIgnore
+  webpackIgnore,
+  webpackPreload,
+  webpackPrefetch
 }
 
 export { commentFor }

--- a/src/util.js
+++ b/src/util.js
@@ -34,4 +34,28 @@ const filepathIsMatch = (filepath, files) => {
   )
 }
 
-export { getOverrideConfig, filepathIsMatch }
+const getOverrideSchema = commentSchema => ({
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      config: commentSchema,
+      files: {
+        oneOf: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          }
+        ]
+      }
+    },
+    additionalProperties: false
+  }
+})
+
+export { getOverrideConfig, getOverrideSchema, filepathIsMatch }

--- a/src/webpackChunkName.js
+++ b/src/webpackChunkName.js
@@ -1,26 +1,24 @@
 import { parse } from 'path'
 
-import { getOverrideConfig } from './util'
+import { getSchema, getConfig } from './booleanComment.js'
 
-const defaultConfig = {
-  active: true,
-  basename: false
-}
-const getConfig = (value, filepath) => {
-  if (value === true) {
-    return defaultConfig
-  }
-
-  let config = { ...defaultConfig, ...value.config }
-
-  if (Array.isArray(value.overrides)) {
-    config = getOverrideConfig(value.overrides, filepath, config)
-  }
-
-  return config
-}
+const schema = getSchema({
+  type: 'object',
+  properties: {
+    active: {
+      type: 'boolean'
+    },
+    basename: {
+      type: 'boolean'
+    }
+  },
+  additionalProperties: false
+})
 const webpackChunkName = (filepath, importPath, value) => {
-  const config = getConfig(value, filepath)
+  const config = getConfig(value, filepath, {
+    active: true,
+    basename: false
+  })
 
   if (!config.active) {
     return ''
@@ -49,4 +47,4 @@ const webpackChunkName = (filepath, importPath, value) => {
   return `webpackChunkName: "${chunkName}"`
 }
 
-export { webpackChunkName }
+export { webpackChunkName, schema }

--- a/src/webpackMode.js
+++ b/src/webpackMode.js
@@ -1,6 +1,32 @@
-import { getOverrideConfig } from './util'
+import { getOverrideConfig, getOverrideSchema } from './util'
 
 const validModes = ['lazy', 'lazy-once', 'eager', 'weak']
+const configSchema = {
+  type: 'object',
+  properties: {
+    active: {
+      type: 'boolean'
+    },
+    mode: {
+      enum: validModes
+    }
+  },
+  additionalProperties: false
+}
+const schema = {
+  anyOf: [
+    { type: 'boolean' },
+    {
+      type: 'object',
+      properties: {
+        config: configSchema,
+        overrides: getOverrideSchema(configSchema.properties)
+      },
+      required: ['config'],
+      additionalProperties: false
+    }
+  ]
+}
 const defaultConfig = {
   active: true,
   mode: 'lazy'
@@ -32,4 +58,4 @@ const webpackMode = (filepath, importPath, value) => {
   return `webpackMode: "${config.mode}"`
 }
 
-export { webpackMode }
+export { webpackMode, schema }

--- a/src/webpackPrefetch.js
+++ b/src/webpackPrefetch.js
@@ -1,14 +1,14 @@
 import { getSchema, getConfig } from './booleanComment.js'
 
 const schema = getSchema()
-const webpackIgnore = (filepath, importPath, value) => {
+const webpackPrefetch = (filepath, importPath, value) => {
   const config = getConfig(value, filepath)
 
   if (!config.active) {
     return ''
   }
 
-  return 'webpackIgnore: true'
+  return 'webpackPrefetch: true'
 }
 
-export { webpackIgnore, schema }
+export { webpackPrefetch, schema }

--- a/src/webpackPreload.js
+++ b/src/webpackPreload.js
@@ -1,14 +1,14 @@
 import { getSchema, getConfig } from './booleanComment.js'
 
 const schema = getSchema()
-const webpackIgnore = (filepath, importPath, value) => {
+const webpackPreload = (filepath, importPath, value) => {
   const config = getConfig(value, filepath)
 
   if (!config.active) {
     return ''
   }
 
-  return 'webpackIgnore: true'
+  return 'webpackPreload: true'
 }
 
-export { webpackIgnore, schema }
+export { webpackPreload, schema }


### PR DESCRIPTION
* `webpackChunkName` now supports globs like `webpackChunkName: 'src/**/*.js'` to activate
* `webpackPreload` is added
* `webpackPrefetch` is added
* Schema validation on comment configurations is added