### PR TITLE
feat: webpackExports, match, and function values

### DIFF
--- a/__tests__/comment.js
+++ b/__tests__/comment.js
@@ -13,10 +13,11 @@ describe('getCommenter', () => {
         webpackChunkName: true,
         webpackMode: 'eager',
         webpackPrefetch: 'some/**/*.js',
-        webpackPreload: false
+        webpackPreload: false,
+        webpackExports: () => ['a', 'b']
       })('import("./some/test/module")', '"./some/test/module"')
     ).toBe(
-      'import(/* webpackChunkName: "some-test-module", webpackMode: "eager", webpackPrefetch: true */ "./some/test/module")'
+      'import(/* webpackChunkName: "some-test-module", webpackMode: "eager", webpackPrefetch: true, webpackExports: ["a", "b"] */ "./some/test/module")'
     )
 
     expect(
@@ -40,5 +41,17 @@ describe('getCommenter', () => {
         webpackChunkName: 'some/**/*.js'
       })('import("./some/test/module")', '"./some/test/module"')
     ).toBe('import(/* webpackChunkName: "some-test-module" */ "./some/test/module")')
+
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackExports: () => ['foo', 'bar']
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe('import(/* webpackExports: ["foo", "bar"] */ "./some/test/module")')
+
+    expect(
+      getCommenter('some/file/path.js', {
+        webpackChunkName: false
+      })('import("./some/test/module")', '"./some/test/module"')
+    ).toBe('import("./some/test/module")')
   })
 })

--- a/__tests__/strategy.js
+++ b/__tests__/strategy.js
@@ -8,7 +8,8 @@ describe('commentFor', () => {
         webpackMode: expect.any(Function),
         webpackIgnore: expect.any(Function),
         webpackPreload: expect.any(Function),
-        webpackPrefetch: expect.any(Function)
+        webpackPrefetch: expect.any(Function),
+        webpackExports: expect.any(Function)
       })
     )
   })

--- a/__tests__/util.js
+++ b/__tests__/util.js
@@ -1,14 +1,14 @@
-import { filepathIsMatch, getOverrideConfig } from '../src/util.js'
+import { pathIsMatch, getOverrideConfig } from '../src/util.js'
 
-describe('filepathIsMatch', () => {
+describe('pathIsMatch', () => {
   it('compares a filepath to glob patterns', () => {
-    expect(filepathIsMatch('some/file/path.js', 'some/**/*.js')).toEqual(true)
-    expect(
-      filepathIsMatch('some/file/path', ['some/**/*.js', '!some/file/*.js'])
-    ).toEqual(false)
-    expect(
-      filepathIsMatch('some/file/path.js', ['some/**/*.js', '!some/miss/*.js'])
-    ).toEqual(true)
+    expect(pathIsMatch('some/file/path.js', 'some/**/*.js')).toEqual(true)
+    expect(pathIsMatch('some/file/path', ['some/**/*.js', '!some/file/*.js'])).toEqual(
+      false
+    )
+    expect(pathIsMatch('some/file/path.js', ['some/**/*.js', '!some/miss/*.js'])).toEqual(
+      true
+    )
   })
 })
 

--- a/__tests__/webpackChunkName.js
+++ b/__tests__/webpackChunkName.js
@@ -4,6 +4,7 @@ describe('webpackChunkName', () => {
   it('returns a "webpackChunkName" magic comment', () => {
     const testPath = 'some/test/module.js'
     const testImportPath = './some/import/path'
+    const testImportPathExt = './some/import/path.js'
 
     expect(webpackChunkName(testPath, testImportPath, true)).toEqual(
       'webpackChunkName: "some-import-path"'
@@ -15,7 +16,21 @@ describe('webpackChunkName', () => {
       webpackChunkName(testPath, testImportPath, ['some/**/*.js', '!some/test/*.js'])
     ).toEqual('')
     expect(
-      webpackChunkName(testPath, testImportPath, { config: { basename: true } })
+      webpackChunkName(testPath, testImportPathExt, 'some/import/**/*.js', 'import')
+    ).toEqual('webpackChunkName: "some-import-path"')
+    expect(
+      webpackChunkName(testPath, testImportPath, 'some/import/**', 'import')
+    ).toEqual('webpackChunkName: "some-import-path"')
+    expect(
+      webpackChunkName(testPath, testImportPathExt, 'some/import/**/*.js', 'module')
+    ).toEqual('')
+    expect(webpackChunkName(testPath, testImportPath, () => 'test-chunk')).toEqual(
+      'webpackChunkName: "test-chunk"'
+    )
+    expect(
+      webpackChunkName(testPath, testImportPath, {
+        config: { active: () => true, basename: true }
+      })
     ).toEqual('webpackChunkName: "path"')
     expect(
       webpackChunkName(testPath, testImportPath, {
@@ -30,8 +45,24 @@ describe('webpackChunkName', () => {
         ]
       })
     ).toEqual('')
+    expect(
+      webpackChunkName(testPath, testImportPath, {
+        config: { basename: true },
+        overrides: [
+          {
+            files: 'notsome/**/*.js',
+            config: {
+              active: false
+            }
+          }
+        ]
+      })
+    ).toEqual('webpackChunkName: "path"')
     expect(webpackChunkName(testPath, './dynamic/${path}.json', true)).toEqual(
       'webpackChunkName: "dynamic-[request]"'
+    )
+    expect(webpackChunkName(testPath, './${path}.json', true)).toEqual(
+      'webpackChunkName: "[request]"'
     )
   })
 })

--- a/__tests__/webpackExports.js
+++ b/__tests__/webpackExports.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals'
+
+import { webpackExports } from '../src/webpackExports.js'
+
+describe('webpackExports', () => {
+  it('returns a "webpackExports" magic comment', () => {
+    const testPath = 'some/test/module.js'
+    const testImportPath = './some/import/path'
+    const exports = jest.fn(() => ['mock'])
+    const comment = webpackExports(testPath, testImportPath, { config: { exports } })
+
+    expect(comment).toEqual('webpackExports: ["mock"]')
+    expect(exports).toHaveBeenCalledWith('some/test/module.js', './some/import/path')
+    expect(webpackExports(testPath, testImportPath, true)).toEqual('')
+    expect(
+      webpackExports(testPath, testImportPath, {
+        config: { active: () => true, exports: () => ['one', 'two'] }
+      })
+    ).toEqual('webpackExports: ["one", "two"]')
+    expect(
+      webpackExports(testPath, testImportPath, {
+        config: { exports: () => "'one', 'two'" }
+      })
+    ).toEqual('')
+    expect(
+      webpackExports(testPath, testImportPath, {
+        config: { exports: () => ['a', 'b'] },
+        overrides: [
+          {
+            files: 'some/**/*.js',
+            config: {
+              active: false
+            }
+          }
+        ]
+      })
+    ).toEqual('')
+  })
+})

--- a/__tests__/webpackIgnore.js
+++ b/__tests__/webpackIgnore.js
@@ -13,6 +13,9 @@ describe('webpackIgnore', () => {
       webpackIgnore(testPath, testImportPath, { config: { active: false } })
     ).toEqual('')
     expect(
+      webpackIgnore(testPath, testImportPath, { config: { active: () => true } })
+    ).toEqual('webpackIgnore: true')
+    expect(
       webpackIgnore(testPath, testImportPath, {
         config: { active: false },
         overrides: [

--- a/__tests__/webpackMode.js
+++ b/__tests__/webpackMode.js
@@ -5,10 +5,17 @@ describe('webpackMode', () => {
     const testPath = 'some/test/module.js'
     const testImportPath = './some/import/path'
 
+    expect(webpackMode(testPath, testImportPath, true)).toEqual('webpackMode: "lazy"')
     expect(webpackMode(testPath, testImportPath, 'eager')).toEqual('webpackMode: "eager"')
-    expect(webpackMode(testPath, testImportPath, { config: { mode: 'lazy' } })).toEqual(
-      'webpackMode: "lazy"'
+    expect(webpackMode(testPath, testImportPath, () => 'lazy-once')).toEqual(
+      'webpackMode: "lazy-once"'
     )
+    expect(webpackMode(testPath, testImportPath, () => 'invalid')).toEqual('')
+    expect(
+      webpackMode(testPath, testImportPath, {
+        config: { mode: () => 'lazy', active: () => true }
+      })
+    ).toEqual('webpackMode: "lazy"')
     expect(
       webpackMode(testPath, testImportPath, {
         config: { mode: 'weak' },

--- a/__tests__/webpackPrefetch.js
+++ b/__tests__/webpackPrefetch.js
@@ -15,6 +15,13 @@ describe('webpackPrefetch', () => {
       webpackPrefetch(testPath, testImportPath, { config: { active: false } })
     ).toEqual('')
     expect(
+      webpackPrefetch(testPath, testImportPath, { config: { active: () => true } })
+    ).toEqual('webpackPrefetch: true')
+    expect(webpackPrefetch(testPath, testImportPath, () => true)).toEqual(
+      'webpackPrefetch: true'
+    )
+    expect(webpackPrefetch(testPath, testImportPath, () => false)).toEqual('')
+    expect(
       webpackPrefetch(testPath, testImportPath, {
         config: { active: false },
         overrides: [

--- a/__tests__/webpackPreload.js
+++ b/__tests__/webpackPreload.js
@@ -13,6 +13,13 @@ describe('webpackPreload', () => {
       webpackPreload(testPath, testImportPath, { config: { active: false } })
     ).toEqual('')
     expect(
+      webpackPreload(testPath, testImportPath, { config: { active: () => true } })
+    ).toEqual('webpackPreload: true')
+    expect(webpackPreload(testPath, testImportPath, () => true)).toEqual(
+      'webpackPreload: true'
+    )
+    expect(webpackPreload(testPath, testImportPath, () => false)).toEqual('')
+    expect(
       webpackPreload(testPath, testImportPath, {
         config: { active: false },
         overrides: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Add webpack magic comments to your dynamic imports during build time",
   "main": "dist",
   "type": "module",

--- a/src/comment.js
+++ b/src/comment.js
@@ -1,22 +1,25 @@
 import { commentFor } from './strategy.js'
 
-const getCommenter = (filepath, options) => (match, capturedImportPath) => {
+const getCommenter = (filepath, options) => (rgxMatch, capturedImportPath) => {
   const importPath = capturedImportPath.trim()
-  const { verbose, ...magicCommentOptions } = options
+  const bareImportPath = importPath.replace(/['"`]/g, '')
+  const { verbose, match, ...magicCommentOptions } = options
   const magicComment = Object.keys(magicCommentOptions)
     .map(key => {
       const option = magicCommentOptions[key]
 
       if (option) {
-        return commentFor[key](filepath, importPath, option)
+        return commentFor[key](filepath, bareImportPath, option, match)
       }
 
       return null
     })
     .filter(comment => comment)
-  const magicImport = match.replace(
+  const magicImport = rgxMatch.replace(
     capturedImportPath,
-    `/* ${magicComment.join(', ')} */ ${importPath}`
+    magicComment.length > 0
+      ? `/* ${magicComment.join(', ')} */ ${importPath}`
+      : `${importPath}`
   )
 
   if (verbose) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -17,7 +17,7 @@ const loader = function (source, map, meta) {
   const filepath = this.utils.contextify(this.rootContext, this.resourcePath)
   const magicComments = getCommenter(
     filepath.replace(/^\.\/?/, ''),
-    optionKeys.length > 0 ? options : { webpackChunkName: true }
+    optionKeys.length > 0 ? options : { match: 'module', webpackChunkName: true }
   )
 
   this.callback(

--- a/src/schema.js
+++ b/src/schema.js
@@ -3,6 +3,7 @@ import { schema as webpackModeSchema } from './webpackMode.js'
 import { schema as webpackIgnoreSchema } from './webpackIgnore.js'
 import { schema as webpackPrefetchSchema } from './webpackPrefetch.js'
 import { schema as webpackPreloadSchema } from './webpackPreload.js'
+import { schema as webpackExportsSchema } from './webpackExports.js'
 
 const schema = {
   type: 'object',
@@ -10,11 +11,15 @@ const schema = {
     verbose: {
       type: 'boolean'
     },
+    match: {
+      enum: ['module', 'import']
+    },
     webpackChunkName: webpackChunkNameSchema,
     webpackMode: webpackModeSchema,
     webpackIgnore: webpackIgnoreSchema,
     webpackPrefetch: webpackPrefetchSchema,
-    webpackPreload: webpackPreloadSchema
+    webpackPreload: webpackPreloadSchema,
+    webpackExports: webpackExportsSchema
   },
   additionalProperties: false
 }

--- a/src/strategy.js
+++ b/src/strategy.js
@@ -3,13 +3,15 @@ import { webpackMode } from './webpackMode.js'
 import { webpackIgnore } from './webpackIgnore.js'
 import { webpackPreload } from './webpackPreload.js'
 import { webpackPrefetch } from './webpackPrefetch.js'
+import { webpackExports } from './webpackExports.js'
 
 const commentFor = {
   webpackChunkName,
   webpackMode,
   webpackIgnore,
   webpackPreload,
-  webpackPrefetch
+  webpackPrefetch,
+  webpackExports
 }
 
 export { commentFor }

--- a/src/util.js
+++ b/src/util.js
@@ -1,18 +1,6 @@
 import micromatch from 'micromatch'
 
-const getOverrideConfig = (overrides, filepath, config) => {
-  const length = overrides.length
-
-  for (let i = 0; i < length; i++) {
-    if (filepathIsMatch(filepath, overrides[i].files)) {
-      return { ...config, ...overrides[i].config }
-    }
-  }
-
-  return config
-}
-
-const filepathIsMatch = (filepath, files) => {
+const pathIsMatch = (path, files) => {
   const globs = []
   const notglobs = []
 
@@ -29,11 +17,10 @@ const filepathIsMatch = (filepath, files) => {
   })
 
   return (
-    (globs.length === 0 || globs.some(glob => micromatch.isMatch(filepath, glob))) &&
-    notglobs.every(notglob => micromatch.isMatch(filepath, notglob))
+    (globs.length === 0 || globs.some(glob => micromatch.isMatch(path, glob))) &&
+    notglobs.every(notglob => micromatch.isMatch(path, notglob))
   )
 }
-
 const getOverrideSchema = commentSchema => ({
   type: 'array',
   items: {
@@ -57,5 +44,17 @@ const getOverrideSchema = commentSchema => ({
     additionalProperties: false
   }
 })
+const getOverrideConfig = (overrides, filepath, config) => {
+  const length = overrides.length
 
-export { getOverrideConfig, getOverrideSchema, filepathIsMatch }
+  for (let i = 0; i < length; i++) {
+    if (pathIsMatch(filepath, overrides[i].files)) {
+      return { ...config, ...overrides[i].config }
+    }
+  }
+
+  return config
+}
+const importPrefix = /^(?:(\.{1,2}\/)+)|^\/|^.+:\/\/\/?[.-\w]+\//
+
+export { getOverrideConfig, getOverrideSchema, pathIsMatch, importPrefix }

--- a/src/webpackIgnore.js
+++ b/src/webpackIgnore.js
@@ -1,10 +1,14 @@
 import { getSchema, getConfig } from './booleanComment.js'
 
 const schema = getSchema()
-const webpackIgnore = (filepath, importPath, value) => {
-  const config = getConfig(value, filepath)
+const webpackIgnore = (filepath, importPath, value, match) => {
+  const config = getConfig(value, match, filepath, importPath)
+  const isActive =
+    typeof config.active === 'function'
+      ? config.active(filepath, importPath)
+      : config.active
 
-  if (!config.active) {
+  if (!isActive) {
     return ''
   }
 

--- a/src/webpackPrefetch.js
+++ b/src/webpackPrefetch.js
@@ -1,10 +1,14 @@
 import { getSchema, getConfig } from './booleanComment.js'
 
 const schema = getSchema()
-const webpackPrefetch = (filepath, importPath, value) => {
-  const config = getConfig(value, filepath)
+const webpackPrefetch = (filepath, importPath, value, match) => {
+  const config = getConfig(value, match, filepath, importPath)
+  const isActive =
+    typeof config.active === 'function'
+      ? config.active(filepath, importPath)
+      : config.active
 
-  if (!config.active) {
+  if (!isActive) {
     return ''
   }
 

--- a/src/webpackPreload.js
+++ b/src/webpackPreload.js
@@ -1,10 +1,14 @@
 import { getSchema, getConfig } from './booleanComment.js'
 
 const schema = getSchema()
-const webpackPreload = (filepath, importPath, value) => {
-  const config = getConfig(value, filepath)
+const webpackPreload = (filepath, importPath, value, match) => {
+  const config = getConfig(value, match, filepath, importPath)
+  const isActive =
+    typeof config.active === 'function'
+      ? config.active(filepath, importPath)
+      : config.active
 
-  if (!config.active) {
+  if (!isActive) {
     return ''
   }
 


### PR DESCRIPTION
* Adds `webpackExports` option
* Adds `match` option to configure which paths are matched against provided globs (module or import)
* Adds `Function` values for comment options to better control comment usage 
* Improves the documentation