### PR TITLE
fix: ignore imports inside strings better

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you must have a multiline comment then this style is ok (only one `import()` 
  */
 ```
 
-This module uses a [RegExp](https://github.com/morganney/magic-comments-loader/blob/master/src/loader.js#L8) not a parser. If you would like to add better support for ignoring `import()` behind multiline comments please open a pull request. See some more [examples on regexr](https://regexr.com/65fg0).
+This module uses a RegExp not a parser. If you would like to add better support for ignoring `import()` behind multiline comments please open a pull request. See some more [examples on regexr](https://regexr.com/65fg0).
 
 ### Configuration
 

--- a/__tests__/util.js
+++ b/__tests__/util.js
@@ -1,4 +1,33 @@
-import { pathIsMatch, getOverrideConfig } from '../src/util.js'
+import {
+  pathIsMatch,
+  getOverrideConfig,
+  dynamicImportsWithoutComments
+} from '../src/util.js'
+
+describe('dynamicImportsWithoutComments', () => {
+  it('is a regex to match dyanmic imports', () => {
+    expect(
+      `const str = 'import("some/path")'`.replace(dynamicImportsWithoutComments, 'test')
+    ).toEqual(`const str = 'import("some/path")'`)
+    expect('import("some/path")'.replace(dynamicImportsWithoutComments, 'test')).toEqual(
+      'test'
+    )
+    expect(
+      `import(
+      "some/path"
+    )`.replace(dynamicImportsWithoutComments, 'test')
+    ).toEqual('test')
+    expect(
+      `import(/* with comments */ "some/path")`.replace(
+        dynamicImportsWithoutComments,
+        'test'
+      )
+    ).toEqual(`import(/* with comments */ "some/path")`)
+    expect(
+      `console.log('import("some/path")')`.replace(dynamicImportsWithoutComments, 'test')
+    ).toEqual(`console.log('import("some/path")')`)
+  })
+})
 
 describe('pathIsMatch', () => {
   it('compares a filepath to glob patterns', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Add webpack magic comments to your dynamic imports during build time",
   "main": "dist",
   "type": "module",

--- a/src/loader.js
+++ b/src/loader.js
@@ -3,9 +3,8 @@ import { validate } from 'schema-utils'
 
 import { schema } from './schema.js'
 import { getCommenter } from './comment.js'
+import { dynamicImportsWithoutComments } from './util.js'
 
-const dynamicImportsWithoutComments =
-  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?![\s]*?\*\/)/g
 const loader = function (source, map, meta) {
   const options = getOptions(this)
   const optionKeys = Object.keys(options)

--- a/src/util.js
+++ b/src/util.js
@@ -57,7 +57,7 @@ const getOverrideConfig = (overrides, filepath, config) => {
 }
 const importPrefix = /^(?:(\.{1,2}\/)+)|^\/|^.+:\/\/\/?[.-\w]+\//
 const dynamicImportsWithoutComments =
-  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*|['"``]\s*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/g
+  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*|['"`][^)$]*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/g
 
 export {
   getOverrideConfig,

--- a/src/util.js
+++ b/src/util.js
@@ -56,5 +56,13 @@ const getOverrideConfig = (overrides, filepath, config) => {
   return config
 }
 const importPrefix = /^(?:(\.{1,2}\/)+)|^\/|^.+:\/\/\/?[.-\w]+\//
+const dynamicImportsWithoutComments =
+  /(?<![\w.]|#!|\*[\s\w]*?|\/\/\s*|['"``]\s*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/g
 
-export { getOverrideConfig, getOverrideSchema, pathIsMatch, importPrefix }
+export {
+  getOverrideConfig,
+  getOverrideSchema,
+  pathIsMatch,
+  importPrefix,
+  dynamicImportsWithoutComments
+}


### PR DESCRIPTION
* Fixes a bug where imports inside strings were not ignored.
  ```js
  // This will be ignored
  const str = 'abc123 import("some/path")~xyz'
  
  // This will not be ignored (any string with a '$')
  const tmplStr = `abc123~${import('some/module')}~xyz`
  ```