### PR TITLE
ci: run pack before publish.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm test
       - name: Lint
         run: npm run lint
+      - name: Pack
+        run: npm pack
       - name: Push to NPM registry
         uses: JS-DevTools/npm-publish@v2.1.0
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-comments-loader",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Add webpack magic comments to your dynamic imports at build time",
   "main": "dist",
   "type": "module",


### PR DESCRIPTION
* New version of [JS-DevTools/npm-publish](https://github.com/JS-DevTools/npm-publish) requires explicit call to `npm pack` before publishing.