### PR TITLE
feat: add mode option, use parser over regexp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/morganney/magic-comments-loader/actions/workflows/ci.yml/badge.svg)
 [![codecov](https://codecov.io/gh/morganney/magic-comments-loader/branch/master/graph/badge.svg?token=1DWQL43B8V)](https://codecov.io/gh/morganney/magic-comments-loader)
 
-Keep your source code clean, add [magic coments](https://webpack.js.org/api/module-methods/#magic-comments) to your dynamic `import()` statements at build time.
+Keep your source code clean, add [magic comments](https://webpack.js.org/api/module-methods/#magic-comments) to your dynamic `import()` expressions at build time.
 
 ## Getting Started
 
@@ -19,7 +19,7 @@ Next add the loader to your `webpack.config.js` file:
 module: {
   rules: [
     {
-      test: /\.[jt]sx?$/,
+      test: /\.[j]sx?$/,
       use: ['magic-comments-loader']
     }
   ]
@@ -45,6 +45,7 @@ The `webpackChunkName` comment is added by default when registering the loader. 
 Most loader options can be defined with a [`CommentConfig`](#commentconfig) object to support overrides and  suboptions ([`CommentOptions`](#commentoptions)). Options that support globs use [`micromatch`](https://github.com/micromatch/micromatch) for pattern matching.
 
 * [`verbose`](#verbose)
+* [`mode`](#mode)
 * [`match`](#match)
 * [`webpackChunkName`](#webpackchunkname)
 * [`webpackFetchPriority`](#webpackfetchpriority)
@@ -94,6 +95,15 @@ boolean
 **default** `false`
 
 Prints console statements of the module filepath and updated `import()` during the webpack build. Useful for debugging.
+
+### `mode`
+**type**
+```ts
+'parser' | 'regexp'
+```
+**default** `'parser'`
+
+Sets how the loader finds dynamic import expressions in your source code, either using an [ECMAScript parser](https://github.com/acornjs/acorn), or a regular expression. Your mileage may vary when using `'regexp'`.
 
 ### `match`
 **type**
@@ -525,7 +535,7 @@ When using a [`CommentConfig`](#commentconfig) object, you can override the conf
 }
 ```
 
-The `files` and `config` keys are both required, where the former is glob string, or array thereof, and the latter is the associated magic comment's [`CommentOptions`](#commentoptions).
+The `files` and `config` keys are both required, where the former is a glob string, or an array thereof, and the latter is the associated magic comment's [`CommentOptions`](#commentoptions).
 
 Here's a more complete example of how overrides can be applied:
 
@@ -581,3 +591,27 @@ import(/* webpackMode: "lazy" */ './folder/module.js')
 import(/* webpackMode: "eager" */ './eager/module.js')
 import(/* webpackChunkName: "locales-[request]", webpackMode: "lazy-once" */ `./locales/${lang}.json`)
 ```
+
+### TypeScript
+
+When using TypeScript or experimental ECMAScript features <= [stage 3](https://tc39.es/process-document/), i.e. non spec compliant, you must chain the appropriate loaders with `magic-comments-loader` coming after.
+
+For example, if your project source code is written in TypeScript, and you use `babel-loader` to transpile and remove type annotations via `@babel/preset-typescript`, while `tsc` is used for type-checking only, chain loaders like this:
+
+**config**
+```js
+module: {
+  rules: [
+    {
+      test: /\.[jt]sx?$/,
+      // Webpack loader chains are processed in reverse order, i.e. last comes first.
+      use: [
+        'magic-comments-loader',
+        'babel-loader'
+      ]
+    }
+  ]
+}
+```
+
+You would configure `ts-loader` similarly, or any other loader that transpiles your source code into spec compliant ECMAScript.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Next add the loader to your `webpack.config.js` file:
 module: {
   rules: [
     {
-      test: /\.[j]sx?$/,
+      test: /\.jsx?$/,
       use: ['magic-comments-loader']
     }
   ]

--- a/__tests__/__fixtures__/complex.regexp.js
+++ b/__tests__/__fixtures__/complex.regexp.js
@@ -1,7 +1,6 @@
 import('./folder/module.js').then(() => {
   const slug = 'module'
   const json = `foo-bar-baz-${import(`./${slug}.json`)}abc`
-  const myString = 'abc,import("foo/bar")xyz' // In 'regexp' mode this string would be incorrectly targeted
 
   return json
 })
@@ -11,16 +10,7 @@ import('./folder/module.js').then(() => {
 import(/* some comment */ './folder/skip.js')
 
 const foo = './module.json'
-/**
- * regex will miss this one, however webpack does not support this syntax.
- * @see https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
- */
-const bar = import(foo)
-/*
-   This comment style will break the build in regexp mode if it
-   spans more than one line and includes import('module')
-   strings more than once. Like import('module2').
-*/
+const bar = import(foo) // regex will miss this one
 const reg = () => {}
 /**
  * import('@fake/module')

--- a/__tests__/__fixtures__/folder/skip.js
+++ b/__tests__/__fixtures__/folder/skip.js
@@ -1,0 +1,1 @@
+export default {}

--- a/__tests__/comment.js
+++ b/__tests__/comment.js
@@ -10,7 +10,9 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: true
+          magicCommentOptions: {
+            webpackChunkName: true
+          }
         },
         logger
       )('import("./some/test/module.js")', '"./some/test/module.js"')
@@ -20,11 +22,13 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: true,
-          webpackMode: 'eager',
-          webpackPrefetch: 'some/**/*.js',
-          webpackPreload: false,
-          webpackExports: () => ['a', 'b']
+          magicCommentOptions: {
+            webpackChunkName: true,
+            webpackMode: 'eager',
+            webpackPrefetch: 'some/**/*.js',
+            webpackPreload: false,
+            webpackExports: () => ['a', 'b']
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -37,8 +41,10 @@ describe('getCommenter', () => {
         'some/file/path.js',
         {
           verbose: true,
-          webpackPreload: true,
-          webpackChunkName: true
+          magicCommentOptions: {
+            webpackPreload: true,
+            webpackChunkName: true
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -50,7 +56,9 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackIgnore: true
+          magicCommentOptions: {
+            webpackIgnore: true
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -60,7 +68,9 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: 'some/**/*.js'
+          magicCommentOptions: {
+            webpackChunkName: 'some/**/*.js'
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -70,7 +80,9 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackExports: () => ['foo', 'bar']
+          magicCommentOptions: {
+            webpackExports: () => ['foo', 'bar']
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -80,7 +92,9 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: false
+          magicCommentOptions: {
+            webpackChunkName: false
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -90,8 +104,10 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: false,
-          webpackInclude: () => /path\/.+\.json$/
+          magicCommentOptions: {
+            webpackChunkName: false,
+            webpackInclude: () => /path\/.+\.json$/
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')
@@ -101,8 +117,10 @@ describe('getCommenter', () => {
       getCommenter(
         'some/file/path.js',
         {
-          webpackChunkName: false,
-          webpackExclude: () => /path\/.+\.json$/
+          magicCommentOptions: {
+            webpackChunkName: false,
+            webpackExclude: () => /path\/.+\.json$/
+          }
         },
         logger
       )('import("./some/test/module")', '"./some/test/module"')

--- a/__tests__/formatter.js
+++ b/__tests__/formatter.js
@@ -1,0 +1,61 @@
+import { format } from '../src/formatter.js'
+
+describe('format', () => {
+  it('adds magic comments to import expression nodes without comments', () => {
+    const openLen = 'import('.length
+    const commentLen = '/* comment */'.length
+    const importExpr = "import(/* comment */ './folder/module.js')"
+    const src = `${importExpr};`
+    const [magicSrc] = format({
+      match: 'module',
+      source: src,
+      filepath: 'src/module.js',
+      comments: [{ start: openLen, end: openLen + commentLen, commentText: ' comment ' }],
+      magicCommentOptions: { webpackChunkName: true },
+      importExpressionNodes: [
+        {
+          type: 'ImportExpression',
+          start: 0,
+          end: importExpr.length,
+          source: {
+            type: 'Literal',
+            start: 22,
+            end: 40,
+            value: './folder/module.js',
+            raw: "'./folder/module.js'"
+          }
+        }
+      ]
+    })
+
+    expect(magicSrc).toEqual(expect.stringContaining(src))
+  })
+
+  it('skips comment options that return invalid values', () => {
+    const importExpr = "import('./folder/module.js')"
+    const src = `${importExpr};`
+    const [magicSrc] = format({
+      match: 'module',
+      source: src,
+      filepath: 'src/module.js',
+      comments: [],
+      magicCommentOptions: { webpackMode: () => 'invalid' },
+      importExpressionNodes: [
+        {
+          type: 'ImportExpression',
+          start: 0,
+          end: importExpr.length,
+          source: {
+            type: 'Literal',
+            start: 8,
+            end: 26,
+            value: './folder/module.js',
+            raw: "'./folder/module.js'"
+          }
+        }
+      ]
+    })
+
+    expect(magicSrc).toEqual(expect.stringContaining(src))
+  })
+})

--- a/__tests__/parser.js
+++ b/__tests__/parser.js
@@ -1,0 +1,30 @@
+import { parse } from '../src/parser.js'
+
+describe('parse', () => {
+  it('parses 2023 ecmascript and jsx while tracking block comments', () => {
+    const src = `
+    // inline comment
+    const Component = () => {
+      return (
+        <>
+          <LazyRoute
+            path="/skip"
+            component={() =>
+              import(/* comment */ './folder/skip')}
+          />
+          <LazyRoute
+            path="/clusters"
+            component={() =>
+              import(
+                './containers/clusters/ClusterRoutes'
+              )}
+          />
+        </>
+      )
+    }
+    `
+    const { comments } = parse(src)
+
+    expect(comments).toEqual([{ start: 175, end: 188, commentText: ' comment ' }])
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,20 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-comments-loader",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "acorn-jsx-walk": "^2.0.0",
+        "acorn-walk": "^8.2.0",
         "loader-utils": "^3.2.1",
+        "magic-string": "^0.30.0",
         "micromatch": "^4.0.4",
         "schema-utils": "^4.1.0"
       },
@@ -2765,8 +2770,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.18",
@@ -3033,66 +3037,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.9",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
-      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.59.9",
-        "@typescript-eslint/visitor-keys": "5.59.9",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.59.9",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.9.tgz",
@@ -3117,6 +3061,33 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.9",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.9.tgz",
+      "integrity": "sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.9",
+        "@typescript-eslint/visitor-keys": "5.59.9",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
@@ -3340,10 +3311,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3364,9 +3334,21 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA=="
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -7121,6 +7103,17 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magic-comments-loader",
-  "version": "1.5.1",
-  "description": "Add webpack magic comments to your dynamic imports at build time",
+  "version": "1.6.0",
+  "description": "Add webpack magic comments to your dynamic imports at build time.",
   "main": "dist",
   "type": "module",
   "exports": {
@@ -64,7 +64,12 @@
     "webpack": "^5.87.0"
   },
   "dependencies": {
+    "acorn": "^8.9.0",
+    "acorn-jsx": "^5.3.2",
+    "acorn-jsx-walk": "^2.0.0",
+    "acorn-walk": "^8.2.0",
     "loader-utils": "^3.2.1",
+    "magic-string": "^0.30.0",
     "micromatch": "^4.0.4",
     "schema-utils": "^4.1.0"
   }

--- a/src/comment.js
+++ b/src/comment.js
@@ -1,9 +1,10 @@
 import { commentFor } from './strategy.js'
+import { getBareImportSpecifier } from './util.js'
 
 const getCommenter = (filepath, options, logger) => (rgxMatch, capturedImportPath) => {
   const importPath = capturedImportPath.trim()
-  const bareImportPath = importPath.replace(/['"`]/g, '')
-  const { verbose, match, ...magicCommentOptions } = options
+  const bareImportPath = getBareImportSpecifier(importPath)
+  const { verbose, match, magicCommentOptions } = options
   const magicComment = Object.keys(magicCommentOptions)
     .map(key =>
       commentFor[key](filepath, bareImportPath, magicCommentOptions[key], match)
@@ -13,7 +14,7 @@ const getCommenter = (filepath, options, logger) => (rgxMatch, capturedImportPat
     capturedImportPath,
     magicComment.length > 0
       ? `/* ${magicComment.join(', ')} */ ${importPath}`
-      : `${importPath}`
+      : importPath
   )
 
   if (verbose) {

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,0 +1,56 @@
+import MagicString from 'magic-string'
+
+import { commentFor } from './strategy.js'
+import { getBareImportSpecifier } from './util.js'
+
+const format = ({
+  match,
+  source,
+  filepath,
+  comments,
+  magicCommentOptions,
+  importExpressionNodes
+}) => {
+  const magicImports = []
+  const step = 'import('.length
+  const cmts = [...comments]
+  const src = new MagicString(source)
+  const hasComment = node => {
+    const idx = cmts.findIndex(cmt => cmt.start > node.start && cmt.end < node.end)
+    const wasFound = idx > -1
+
+    if (wasFound) {
+      cmts.splice(idx, 1)
+    }
+
+    return wasFound
+  }
+
+  for (const node of importExpressionNodes) {
+    if (!hasComment(node)) {
+      const specifier = source.substring(node.start + step, node.end - 1)
+      const bareImportPath = getBareImportSpecifier(specifier)
+      const magic = Object.keys(magicCommentOptions)
+        .map(key =>
+          commentFor[key](filepath, bareImportPath, magicCommentOptions[key], match)
+        )
+        .filter(Boolean)
+
+      if (magic.length) {
+        const magicComment = `/* ${magic.join(', ')} */ `
+
+        magicImports.push(
+          src
+            .snip(node.start, node.end)
+            .toString()
+            .replace(specifier, `${magicComment}${specifier}`)
+        )
+        src.appendRight(node.start + step, `${magicComment}`)
+      }
+    }
+  }
+
+  return [src.toString(), magicImports]
+}
+
+export { format }

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,30 +1,45 @@
 import { validate } from 'schema-utils'
 
 import { schema } from './schema.js'
+import { parse } from './parser.js'
+import { format } from './formatter.js'
 import { getCommenter } from './comment.js'
 import { dynamicImportsWithoutComments } from './util.js'
 
-const loader = function (source, map, meta) {
+const loader = function (source) {
   const options = this.getOptions()
-  const optionKeys = Object.keys(options)
   const logger = this.getLogger('MCL')
 
   validate(schema, options, {
     name: 'magic-comments-loader'
   })
 
-  const filepath = this.utils.contextify(this.rootContext, this.resourcePath)
-  const magicComments = getCommenter(
-    filepath.replace(/^\.\/?/, ''),
-    optionKeys.length > 0 ? options : { match: 'module', webpackChunkName: true },
-    logger
-  )
+  const { mode = 'parser', match = 'module', verbose = false, ...rest } = options
+  const magicCommentOptions = Object.keys(rest).length ? rest : { webpackChunkName: true }
+  const filepath = this.utils
+    .contextify(this.rootContext, this.resourcePath)
+    .replace(/^\.\/?/, '')
 
-  this.callback(
-    null,
-    source.replace(dynamicImportsWithoutComments, magicComments),
-    map,
-    meta
+  if (mode === 'parser') {
+    const [magicSource, magicImports] = format({
+      ...parse(source),
+      match,
+      filepath,
+      magicCommentOptions
+    })
+
+    if (verbose) {
+      magicImports.forEach(magicImport => {
+        logger.info(`${filepath} : ${magicImport}`)
+      })
+    }
+
+    return magicSource
+  }
+
+  return source.replace(
+    dynamicImportsWithoutComments,
+    getCommenter(filepath, { verbose, match, magicCommentOptions }, logger)
   )
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,44 @@
+import { Parser } from 'acorn'
+import { simple, base } from 'acorn-walk'
+import { extend } from 'acorn-jsx-walk'
+import jsx from 'acorn-jsx'
+
+/**
+ * NOTE: Side-effect of importing this module's exports.
+ *
+ * Extend acorn-walk's base with missing JSX nodes.
+ * @see https://github.com/acornjs/acorn/issues/829
+ *
+ * Consider another parser that supports more syntaxes out-of-the-box.
+ * That would enable less requirements on loader chaining.
+ */
+extend(base)
+
+const jsxParser = Parser.extend(jsx())
+const parse = source => {
+  const comments = []
+  const importExpressionNodes = []
+  const ast = jsxParser.parse(source, {
+    locations: false,
+    ecmaVersion: 2023,
+    sourceType: 'module',
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    allowImportExportEverywhere: true,
+    onComment: (isBlock, commentText, start, end) => {
+      if (isBlock) {
+        comments.push({ start, end, commentText })
+      }
+    }
+  })
+
+  simple(ast, {
+    ImportExpression(node) {
+      importExpressionNodes.push(node)
+    }
+  })
+
+  return { ast, comments, importExpressionNodes, source }
+}
+
+export { parse }

--- a/src/schema.js
+++ b/src/schema.js
@@ -14,6 +14,9 @@ const schema = {
     verbose: {
       type: 'boolean'
     },
+    mode: {
+      enum: ['parser', 'regexp']
+    },
     match: {
       enum: ['module', 'import']
     },

--- a/src/util.js
+++ b/src/util.js
@@ -55,11 +55,15 @@ const getOverrideConfig = (overrides, filepath, config) => {
 
   return config
 }
+const getBareImportSpecifier = specifier => {
+  return specifier.replace(/['"`]/g, '')
+}
 const importPrefix = /^(?:(\.{1,2}\/)+)|^\/|^.+:\/\/\/?[.-\w]+\//
 const dynamicImportsWithoutComments =
   /(?<![\w.]|#!|(?:\/{2}.+\n?)+|\/\*[\s\w]*?|\*.+?|['"`][^)$,\n]*)import\s*\((?!\s*\/\*)(?<path>\s*?['"`][^)]+['"`]\s*)\)(?!\s*?\*\/)/gm
 
 export {
+  getBareImportSpecifier,
   getOverrideConfig,
   getOverrideSchema,
   pathIsMatch,


### PR DESCRIPTION
* Adds `mode` option supporting `'parser'` and `'regexp'` while defaulting to `parser` (using `acorn`).
* Allows `webpackChunkName` option to be active by default if only using `mode`, `match`, `verbose` or a combination thereof. Presence of any other magic comment option will require addition of `webpackChunkName` to activate.
* Updates documentation around chaining loaders with this one, e.g. when using TypeScript.